### PR TITLE
Revert "Bump express-openid-connect from 2.2.1 to 2.3.0 in /api"

### DIFF
--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -17,7 +17,7 @@
                 "dotenv": "^8.2.0",
                 "dotenv-defaults": "^2.0.1",
                 "express": "^4.17.1",
-                "express-openid-connect": "^2.3.0",
+                "express-openid-connect": "^2.2.1",
                 "fs": "0.0.1-security",
                 "into-stream": "^6.0.0",
                 "multer": "^1.4.2",
@@ -2420,9 +2420,9 @@
             }
         },
         "node_modules/express-openid-connect": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-2.3.0.tgz",
-            "integrity": "sha512-cNGS5ddY/BxL9x7eRDgkC4ChH4CHPd3Mig170IsHIbCmo9PNLQvyMmiMCbLyXOMX4RlLnIJI9/+HNV86CX/4uA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-2.2.1.tgz",
+            "integrity": "sha512-0MhVys4Ry/8dgIEpHcBoLixR+oaOjwFo3Edy4Cl8H4tkvQwwLHRzDYPg9jYRVdiikJTLzACjvTNsoFsrw+/ZHw==",
             "dependencies": {
                 "@hapi/joi": "^17.1.1",
                 "base64url": "^3.0.1",
@@ -2433,6 +2433,7 @@
                 "futoin-hkdf": "^1.3.2",
                 "http-errors": "^1.7.3",
                 "jose": "^2.0.0",
+                "on-headers": "^1.0.2",
                 "openid-client": "^4.0.0",
                 "p-memoize": "^4.0.0",
                 "url-join": "^4.0.1"
@@ -4052,6 +4053,14 @@
             "dependencies": {
                 "ee-first": "1.1.1"
             },
+            "engines": {
+                "node": ">= 0.8"
+            }
+        },
+        "node_modules/on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
             "engines": {
                 "node": ">= 0.8"
             }
@@ -8119,9 +8128,9 @@
             }
         },
         "express-openid-connect": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-2.3.0.tgz",
-            "integrity": "sha512-cNGS5ddY/BxL9x7eRDgkC4ChH4CHPd3Mig170IsHIbCmo9PNLQvyMmiMCbLyXOMX4RlLnIJI9/+HNV86CX/4uA==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/express-openid-connect/-/express-openid-connect-2.2.1.tgz",
+            "integrity": "sha512-0MhVys4Ry/8dgIEpHcBoLixR+oaOjwFo3Edy4Cl8H4tkvQwwLHRzDYPg9jYRVdiikJTLzACjvTNsoFsrw+/ZHw==",
             "requires": {
                 "@hapi/joi": "^17.1.1",
                 "base64url": "^3.0.1",
@@ -8132,6 +8141,7 @@
                 "futoin-hkdf": "^1.3.2",
                 "http-errors": "^1.7.3",
                 "jose": "^2.0.0",
+                "on-headers": "^1.0.2",
                 "openid-client": "^4.0.0",
                 "p-memoize": "^4.0.0",
                 "url-join": "^4.0.1"
@@ -9404,6 +9414,11 @@
             "requires": {
                 "ee-first": "1.1.1"
             }
+        },
+        "on-headers": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.2.tgz",
+            "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA=="
         },
         "once": {
             "version": "1.4.0",

--- a/api/package.json
+++ b/api/package.json
@@ -54,7 +54,7 @@
         "dotenv": "^8.2.0",
         "dotenv-defaults": "^2.0.1",
         "express": "^4.17.1",
-        "express-openid-connect": "^2.3.0",
+        "express-openid-connect": "^2.2.1",
         "fs": "0.0.1-security",
         "into-stream": "^6.0.0",
         "multer": "^1.4.2",


### PR DESCRIPTION
Reverts jigar288/CloudVOD#104

Testing for this version is required