### PR TITLE
Use auto-generated thumbnail from azure media service

### DIFF
--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -70,9 +70,7 @@ export default class App {
             exit(1)
 
         // * Bind middlewares
-        // ! FIXME: don't add middlewares that don't need to be called for every route --> example: multer
-        const middlewares = [auth(this.#openIDConfig), express.json(), express.urlencoded({ extended: true }), multer({ storage: multer.memoryStorage() }).single('filetoupload') ]
-        // const middlewares = [auth(this.#openIDConfig), express.json(), express.urlencoded({ extended: true })]
+        const middlewares = [auth(this.#openIDConfig), express.json(), express.urlencoded({ extended: true })]
         this.bindMiddlewares(middlewares)
         
         // * Create and controllers

--- a/api/src/controllers/VideoController.ts
+++ b/api/src/controllers/VideoController.ts
@@ -8,6 +8,8 @@ import { requiresAuth, OpenidRequest, OpenidResponse } from 'express-openid-conn
 import { User } from '../types/User'
 import { Video } from '../types/Video'
 import { PublicAccessType } from '@azure/storage-blob'
+import multer from 'multer'
+
 
 
 export class VideoController extends Controller {
@@ -21,10 +23,8 @@ export class VideoController extends Controller {
         this.#videoDBClient = videoDBClient
     }
 
-    // ! FIXME: only authenticated users should be able to upload files
-    // TODO: look at auth routes for example
     // TODO: move business logic to its own layer?
-    @Post('/video')
+    @Post('/video', [requiresAuth(),  multer({ storage: multer.memoryStorage() }).single('filetoupload') ])
     async upload_video_file(_req: OpenidRequest, res: OpenidResponse): Promise<void> {
 
         const userInfo = _req.oidc.user as User;
@@ -92,7 +92,6 @@ export class VideoController extends Controller {
         this.fail(res, categoriesData.message)
     }
     
-    // ! FIXME: require auth for file uploads
     @Get('/file-upload', [requiresAuth()] )
     async file_uploader(_req: Request, res: Response): Promise<void> {
         res.writeHead(200, { 'Content-Type': 'text/html' })
@@ -182,9 +181,6 @@ export class VideoController extends Controller {
             }
         }
     }      
-
-    
-    // TODO: add route to get video metadata such as streaming url, title, etc --> both authenticated & unauthenticated should have access
 
     @Get('/video-test')
     async video_test(req: Request, res: Response): Promise<void> {

--- a/api/src/data/VideoDatabaseClient.ts
+++ b/api/src/data/VideoDatabaseClient.ts
@@ -124,14 +124,12 @@ class VideoDatabaseClient {
          * @param assetName The unique output asset name from azure media service that contains files for the video 
          * @returns DBQueryResponse
          */
-        update: async (streamingURL: string, outputAssetName: string): Promise<DBQueryResponse> => {
+        update: async (streamingURL: string, outputAssetName: string, thumbnailURL: string): Promise<DBQueryResponse> => {
             const queryResult: DBQueryResponse = { data: null, wasRequestSuccessful: false, message: '' }
-
-            const tempThumbnailURL = `https://mcdn.wallpapersafari.com/medium/4/69/dc7soF.jpg`;
 
             try{
                 const updateQuery = 'CALL update_video_metadata($1, $2, $3);'
-                await this.#videoDatabaseClient.query(updateQuery, [streamingURL, tempThumbnailURL, outputAssetName] );
+                await this.#videoDatabaseClient.query(updateQuery, [streamingURL, thumbnailURL, outputAssetName] );
                 queryResult.wasRequestSuccessful = true;
                 queryResult.message = 'Success updating streaming url'            
             }catch(error){

--- a/sql-code/sql-functions-and-procedures/video/get_all_video_data.sql
+++ b/sql-code/sql-functions-and-procedures/video/get_all_video_data.sql
@@ -24,7 +24,6 @@ BEGIN
 END; $$;
 
 
--- FIXME: incrementally debug this & narrowing down syntax issue by removing small parts of statement
 -- SELECT * FROM get_all_video_data();
 
 -- !fixme: USE TYPES WHEN RETURNING DATA TO TYPESCRIPT api


### PR DESCRIPTION
- added method to change container access policy which must be called after encoding job is complete otherwise policy will be overwritten
- allowing public access to asset folder that contains thumbnail
- added method to get url of blob to get thumbnail url
- entering thumbnail url to DB 
- refactor: created diff method to get container name